### PR TITLE
fix: require color

### DIFF
--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -27,7 +27,7 @@
 
 ;;; Code:
 (require 'mu4e)
-
+(require 'color)
 
 (defvar mu4e-headers-thread-base-color "#673AB7")
 


### PR DESCRIPTION
Without this calls of `color-lighten-name` are void