### PR TITLE
Big changes and refactoring, fix several issues as well

### DIFF
--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -186,8 +186,7 @@ This uses the mu4e private API and this might break in future releases."
 
                   ;; Warning: might break in the future
                   (docid (mu4e-message-field msg :docid))
-                  (prefix-start (+ (length mu4e~mark-fringe)
-                                   (mu4e~headers-goto-docid docid t)))
+                  (prefix-start (save-excursion (mu4e~headers-goto-docid docid t)))
 
                   (unread (member 'unread (mu4e-message-field msg :flags)))
 
@@ -318,7 +317,6 @@ Unread message are not folded."
             (while (not (bobp))
               (cl-loop for ov in (overlays-in (save-excursion
                                                 (forward-line 0)
-                                                (move-to-column 3 t)
                                                 (point))
                                               (point-at-eol))
                        when (overlay-get ov 'thread-child)

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -158,7 +158,7 @@ This uses the mu4e private API and this might break in future releases."
       (remove-overlays (point-min) (point-max))
 
       (let ((overlay-priority     -60)
-            (folded               (if (string= mu4e-thread-folding-default-view 'folded) t nil))
+            (folded               (string= mu4e-thread-folding-default-view 'folded))
 
             (child-face           'mu4e-thread-folding-child-face)
             (child-prefix-beg     (car mu4e-thread-folding-child-prefix-position))

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -55,6 +55,8 @@
 (require 'mu4e)
 (require 'color)
 
+(defvar mu4e-thread-folding-mode nil)
+
 (defun color-darken (hexcolor percent)
   (pcase-let* ((`(,R ,G ,B) (color-name-to-rgb hexcolor))
                (`(,H ,S ,L) (color-rgb-to-hsl R G B))
@@ -263,7 +265,6 @@ Unread message are not folded."
         (goto-char (point-min))
         (let ((root-overlay  nil)
               (child-overlay nil)
-              (root-prefix-beg (car mu4e-thread-folding-root-prefix-position))
               (root-folded-face 'mu4e-thread-folding-root-folded-face)
               (root-unfolded-face 'mu4e-thread-folding-root-unfolded-face)
               (root-folded-prefix mu4e-thread-folding-root-folded-prefix-string)

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -367,49 +367,28 @@ Unread message are not folded."
         (let ((overlay (mu4e-headers-get-overlay 'thread-id)))
           (mu4e-headers-overlay-set-visibility nil (overlay-get overlay 'thread-id))))))
 
-(defvar mu4e-thread-folding-map
-  (make-sparse-keymap))
+(defvar mu4e-thread-folding-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map mu4e-headers-mode-map)
+    (define-key map (kbd "TAB") 'mu4e-headers-toggle-at-point)
+    (define-key map (kbd "S-<tab>") 'mu4e-headers-toggle-fold-all)
+    map))
 
-;; (define-key mu4e-thread-folding-map (kbd "<left>") 'mu4e-headers-fold-at-point)
-;; (define-key mu4e-thread-folding-map (kbd "<S-left>") 'mu4e-headers-fold-all)
-;; (define-key mu4e-thread-folding-map (kbd "<right>") 'mu4e-headers-unfold-at-point)
-;; (define-key mu4e-thread-folding-map (kbd "<S-right>") 'mu4e-headers-unfold-all)
-(define-key mu4e-thread-folding-map (kbd "TAB") 'mu4e-headers-toggle-at-point)
-(define-key mu4e-thread-folding-map (kbd "S-<tab>") 'mu4e-headers-toggle-fold-all)
-
-(define-minor-mode mu4e-thread-folding-mode
-  "Minor mode for folding threads in mu4e-headers view."
-  ;; The initial value - Set to 1 to enable by default
-  nil
-  ;; The indicator for the mode line.
-  " Threads"
-  ;; The minor mode keymap
-  mu4e-thread-folding-map
-  ;; Make mode global rather than buffer local
-  :global nil
-  ;; customization group
-  :group 'mu4e-thread-folding)
-
-;; Install hooks and keybindings
+;; Install hooks
 (defun mu4e-thread-folding-load ()
   "Install hooks."
   (add-hook 'mu4e-index-updated-hook #'mu4e-headers-mark-threads)
   (add-hook 'mu4e-headers-found-hook #'mu4e-headers-mark-threads))
 
-(mu4e-thread-folding-load)
+(define-minor-mode mu4e-thread-folding-mode
+  "Minor mode for folding threads in mu4e-headers view."
+  :group 'mu4e-thread-folding
+  :lighter " Threads"
+  (if mu4e-thread-folding-mode
+      (mu4e-thread-folding-load)
+    (remove-hook 'mu4e-index-updated-hook #'mu4e-headers-mark-threads)
+    (remove-hook 'mu4e-headers-found-hook #'mu4e-headers-mark-threads)))
 
-(defun mu4e-thread-folding-unload-function ()
-  "Handler for `unload-feature'."
-  (condition-case err
-      (progn
-        (remove-hook 'mu4e-index-updated-hook #'mu4e-headers-mark-threads)
-        (remove-hook 'mu4e-headers-found-hook #'mu4e-headers-mark-threads)
-        ;; Return nil if unloading was successful.  Refer to `unload-feature'.
-        nil)
-    ;; If any error occurred, return non-nil.
-    (error (progn
-             (message "Error unloading mu4e-thread-folding: %S %S" (car err) (cdr err))
-             t))))
 
 (provide 'mu4e-thread-folding)
 ;;; mu4e-thread-folding.el ends here

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -261,8 +261,8 @@ Unread message are not folded."
                      (unread (overlay-get local-child-overlay 'unread)))
                  (setq child-overlay local-child-overlay)
                  (when (or (not thread-id) (string= id thread-id))
-                   (if unread
-                       (and root-overlay (overlay-put root-overlay 'face root-unfolded-face))
+                   (if (and root-overlay unread)
+                       (overlay-put root-overlay 'face root-unfolded-face)
                      (overlay-put child-overlay 'invisible value)))))
              ;; Root header
              (when local-root-overlay

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -373,7 +373,8 @@ Unread message are not folded."
 (defun mu4e-thread-folding-load ()
   "Install hooks."
   (add-hook 'mu4e-index-updated-hook #'mu4e-headers-mark-threads)
-  (add-hook 'mu4e-headers-found-hook #'mu4e-headers-mark-threads))
+  (add-hook 'mu4e-headers-found-hook #'mu4e-headers-mark-threads)
+  (add-hook 'mu4e-view-mode-hook 'mu4e-headers-mark-threads-no-reset))
 
 ;;;###autoload
 (define-minor-mode mu4e-thread-folding-mode
@@ -383,7 +384,8 @@ Unread message are not folded."
   (if mu4e-thread-folding-mode
       (mu4e-thread-folding-load)
     (remove-hook 'mu4e-index-updated-hook #'mu4e-headers-mark-threads)
-    (remove-hook 'mu4e-headers-found-hook #'mu4e-headers-mark-threads)))
+    (remove-hook 'mu4e-headers-found-hook #'mu4e-headers-mark-threads)
+    (remove-hook 'mu4e-view-mode-hook 'mu4e-headers-mark-threads-no-reset)))
 
 
 (provide 'mu4e-thread-folding)

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -242,7 +242,7 @@ Unread message are not folded."
   (when (and (get-buffer "*mu4e-headers*") mu4e-headers-show-threads)
     (with-current-buffer "*mu4e-headers*"
       (unless thread-id
-        (setq mu4e-thread-folding-all-folded (not value)))
+        (setq mu4e-thread-folding-all-folded value))
       (save-excursion
         (goto-char (point-min))
         (let ((root-overlay  nil)
@@ -322,7 +322,7 @@ Unread message are not folded."
 (defun mu4e-headers-toggle-fold-all ()
   "Toggle between all threads unfolded and all threads folded."
   (interactive)
-  (mu4e-headers-overlay-set-visibility mu4e-thread-folding-all-folded))
+  (mu4e-headers-overlay-set-visibility (not mu4e-thread-folding-all-folded)))
 
 (defun mu4e-headers-fold-all ()
   "Fold all threads"

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -179,7 +179,7 @@ This uses the mu4e private API and this might break in future releases."
                                          (+ prefix-start child-prefix-end)))
                   ;; Overlay for child (whole line)
                   (child-overlay (make-overlay
-                                  (+ 0 (line-beginning-position))
+                                  (line-beginning-position)
                                   (+ 1 (line-end-position)))))
              (setq folded (or (and (member id mu4e-headers--folded-items) t)
                               mu4e-thread-folding-all-folded))
@@ -270,6 +270,10 @@ Unread message are not folded."
                       (root-prefix-overlay (overlay-get local-root-overlay 'prefix-overlay)))
                  (setq root-overlay local-root-overlay)
                  (when (or (not thread-id) (string= id thread-id))
+                   (if (and (overlay-get root-overlay 'folded) (null value))
+                       (setq mu4e-headers--folded-items
+                             (delete id mu4e-headers--folded-items))
+                     (push id mu4e-headers--folded-items))
                    (overlay-put root-overlay 'folded value)
                    (overlay-put root-prefix-overlay
                                 'display (if value root-folded-prefix root-unfolded-prefix))
@@ -301,10 +305,6 @@ Unread message are not folded."
     (cond (root-overlay
            (let ((id     (overlay-get root-overlay 'thread-id))
                  (folded (overlay-get root-overlay 'folded)))
-             (if folded
-                 (setq mu4e-headers--folded-items
-                       (delete id mu4e-headers--folded-items))
-               (push id mu4e-headers--folded-items))
              (mu4e-headers-overlay-set-visibility (not folded) id)
              (throw 'break t)))
           ((not child-overlay)

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -144,6 +144,7 @@ This uses the mu4e private API and this might break in future releases."
     (with-current-buffer "*mu4e-headers*"
       ;; turn on minor mode for key bindings
       (unless mu4e-thread-folding-mode (mu4e-thread-folding-mode 1))
+      (setq-local line-move-ignore-invisible t)
       ;; Remove all overlays
       (remove-overlays (point-min) (point-max))
       (unless no-reset (setq mu4e-headers--folded-items nil))
@@ -163,6 +164,7 @@ This uses the mu4e private API and this might break in future releases."
             (root-prefix-end      (cdr mu4e-thread-folding-root-prefix-position))
             (root-folded-prefix   mu4e-thread-folding-root-folded-prefix-string)
             (root-unfolded-prefix mu4e-thread-folding-root-unfolded-prefix-string))
+        (setq-local line-move-visual t)
         ;; store initial folded state
         (setq mu4e-thread-folding-all-folded folded)
         ;; Iterate over each header

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -241,45 +241,43 @@ This uses the mu4e private API and this might break in future releases."
 Unread message are not folded."
   (when (and (get-buffer "*mu4e-headers*") mu4e-headers-show-threads)
     (with-current-buffer "*mu4e-headers*"
-      (save-excursion
-        (goto-char (point-min))
-        (let ((root-overlay  nil)
-              (child-overlay nil)
-              (root-folded-face 'mu4e-thread-folding-root-folded-face)
-              (root-unfolded-face 'mu4e-thread-folding-root-unfolded-face)
-              (root-folded-prefix mu4e-thread-folding-root-folded-prefix-string)
-              (root-unfolded-prefix mu4e-thread-folding-root-unfolded-prefix-string))
-          (while (not (eobp))
-            (let (local-child-overlay local-root-overlay)
-              (cl-loop for ov in (overlays-at (point))
-                       when (overlay-get ov 'thread-child)
-                       do (setq local-child-overlay ov)
-                       when (overlay-get ov 'thread-root)
-                       do (setq local-root-overlay ov))
-              ;; Child header
-              (when local-child-overlay
-                (let ((id     (overlay-get local-child-overlay 'thread-id))
-                      (unread (overlay-get local-child-overlay 'unread)))
-                  (setq child-overlay local-child-overlay)
-                  (when (or (not thread-id) (string= id thread-id))
-                    (if unread
-                        (and root-overlay (overlay-put root-overlay 'face root-unfolded-face))
-                      (overlay-put child-overlay 'invisible value)))))
-              ;; Root header
-              (when local-root-overlay
-                (let* ((id                  (overlay-get local-root-overlay 'thread-id))
-                       (root-prefix-overlay (overlay-get local-root-overlay 'prefix-overlay)))
-                  (setq root-overlay local-root-overlay)
-                  (when (or (not thread-id) (string= id thread-id))
-                    (overlay-put root-overlay 'folded value)
-                    (overlay-put root-prefix-overlay
-                                 'display (if value root-folded-prefix root-unfolded-prefix))
-                    (overlay-put root-overlay
-                                 'face (if value root-folded-face root-unfolded-face)))))
-              ;; Not a root, not a child, we reset the root overlay
-              (when (and (not local-child-overlay) (not local-root-overlay))
-                (setq root-overlay nil))
-              (forward-line 1))))))))
+      (let ((root-overlay  nil)
+            (child-overlay nil)
+            (root-folded-face 'mu4e-thread-folding-root-folded-face)
+            (root-unfolded-face 'mu4e-thread-folding-root-unfolded-face)
+            (root-folded-prefix mu4e-thread-folding-root-folded-prefix-string)
+            (root-unfolded-prefix mu4e-thread-folding-root-unfolded-prefix-string))
+        (mu4e-headers-for-each
+         (lambda (_msg)
+           (let (local-child-overlay local-root-overlay)
+             (cl-loop for ov in (overlays-at (point))
+                      when (overlay-get ov 'thread-child)
+                      do (setq local-child-overlay ov)
+                      when (overlay-get ov 'thread-root)
+                      do (setq local-root-overlay ov))
+             ;; Child header
+             (when local-child-overlay
+               (let ((id     (overlay-get local-child-overlay 'thread-id))
+                     (unread (overlay-get local-child-overlay 'unread)))
+                 (setq child-overlay local-child-overlay)
+                 (when (or (not thread-id) (string= id thread-id))
+                   (if unread
+                       (and root-overlay (overlay-put root-overlay 'face root-unfolded-face))
+                     (overlay-put child-overlay 'invisible value)))))
+             ;; Root header
+             (when local-root-overlay
+               (let* ((id                  (overlay-get local-root-overlay 'thread-id))
+                      (root-prefix-overlay (overlay-get local-root-overlay 'prefix-overlay)))
+                 (setq root-overlay local-root-overlay)
+                 (when (or (not thread-id) (string= id thread-id))
+                   (overlay-put root-overlay 'folded value)
+                   (overlay-put root-prefix-overlay
+                                'display (if value root-folded-prefix root-unfolded-prefix))
+                   (overlay-put root-overlay
+                                'face (if value root-folded-face root-unfolded-face)))))
+             ;; Not a root, not a child, we reset the root overlay
+             (when (and (not local-child-overlay) (not local-root-overlay))
+               (setq root-overlay nil)))))))))
 
 
 (defun mu4e-headers-toggle-at-point ()

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -148,8 +148,6 @@ This uses the mu4e private API and this might break in future releases."
 
 (defun mu4e-headers-mark-threads ()
   "Mark line in headers view with various information contained in overlays."
-
-  (interactive)
   (when (and (get-buffer "*mu4e-headers*") mu4e-headers-show-threads)
     (with-current-buffer "*mu4e-headers*"
       ;; turn on minor mode for key bindings
@@ -257,8 +255,6 @@ This uses the mu4e private API and this might break in future releases."
 (defun mu4e-headers-overlay-set-visibility (value &optional thread-id)
   "Set the invisible property for all thread children or only the ones matching thread-id.
 Unread message are not folded."
-
-  (interactive)
   (when (and (get-buffer "*mu4e-headers*") mu4e-headers-show-threads)
     (with-current-buffer "*mu4e-headers*"
       (unless thread-id

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -306,10 +306,9 @@ Unread message are not folded."
   (when (get-buffer "*mu4e-headers*")
     (with-current-buffer "*mu4e-headers*"
       (catch 'break
-        (save-excursion
-          (while (and (not (mu4e-headers--toggle-internal))
-                      (not (bobp)))
-            (forward-line -1)))))))
+        (while (and (not (mu4e-headers--toggle-internal))
+                    (not (bobp)))
+          (forward-line -1))))))
 
 (defun mu4e-headers--toggle-internal ()
   "Toggle visibility of the thread at point"

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -251,7 +251,6 @@ Unread message are not folded."
               (root-unfolded-face 'mu4e-thread-folding-root-unfolded-face)
               (root-folded-prefix mu4e-thread-folding-root-folded-prefix-string)
               (root-unfolded-prefix mu4e-thread-folding-root-unfolded-prefix-string))
-
           (while (not (eobp))
             (let (local-child-overlay local-root-overlay)
               (cl-loop for ov in (overlays-at (point))
@@ -264,11 +263,10 @@ Unread message are not folded."
                 (let ((id     (overlay-get local-child-overlay 'thread-id))
                       (unread (overlay-get local-child-overlay 'unread)))
                   (setq child-overlay local-child-overlay)
-                  (if (or (not thread-id) (string= id thread-id))
-                      (if unread
-                          (if root-overlay (overlay-put root-overlay 'face root-unfolded-face))
-                        (overlay-put child-overlay 'invisible value)))))
-
+                  (when (or (not thread-id) (string= id thread-id))
+                    (if unread
+                        (and root-overlay (overlay-put root-overlay 'face root-unfolded-face))
+                      (overlay-put child-overlay 'invisible value)))))
               ;; Root header
               (when local-root-overlay
                 (let* ((id                  (overlay-get local-root-overlay 'thread-id))
@@ -276,16 +274,13 @@ Unread message are not folded."
                   (setq root-overlay local-root-overlay)
                   (when (or (not thread-id) (string= id thread-id))
                     (overlay-put root-overlay 'folded value)
-                    (if value
-                        (progn (overlay-put root-prefix-overlay 'display root-folded-prefix)
-                               (overlay-put root-overlay 'face root-folded-face))
-                      (progn (overlay-put root-prefix-overlay 'display root-unfolded-prefix)
-                             (overlay-put root-overlay 'face root-unfolded-face))))))
-
+                    (overlay-put root-prefix-overlay
+                                 'display (if value root-folded-prefix root-unfolded-prefix))
+                    (overlay-put root-overlay
+                                 'face (if value root-folded-face root-unfolded-face)))))
               ;; Not a root, not a child, we reset the root overlay
               (when (and (not local-child-overlay) (not local-root-overlay))
                 (setq root-overlay nil))
-
               (forward-line 1))))))))
 
 

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -380,6 +380,7 @@ Unread message are not folded."
   (add-hook 'mu4e-index-updated-hook #'mu4e-headers-mark-threads)
   (add-hook 'mu4e-headers-found-hook #'mu4e-headers-mark-threads))
 
+;;;###autoload
 (define-minor-mode mu4e-thread-folding-mode
   "Minor mode for folding threads in mu4e-headers view."
   :group 'mu4e-thread-folding

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -371,7 +371,7 @@ Unread message are not folded."
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map mu4e-headers-mode-map)
     (define-key map (kbd "TAB") 'mu4e-headers-toggle-at-point)
-    (define-key map (kbd "S-<tab>") 'mu4e-headers-toggle-fold-all)
+    (define-key map (kbd "<C-tab>") 'mu4e-headers-toggle-fold-all)
     map))
 
 ;; Install hooks

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -80,30 +80,19 @@
 
 (defface mu4e-thread-folding-root-unfolded-face
   `((t :extend t
-       :overline nil ;; ,(color-darken nano-color-background 10)
-       :underline nil
-       :foreground nil
-       :background ,(color-darken
-                     (face-attribute 'default :background) 3)))
+       :background "Palegreen4"))
   "Face for the root node thread when it is unfolded."
   :group 'mu4e-thread-folding)
 
 (defface mu4e-thread-folding-root-folded-face
-  '((t :inherit nil
-       :overline nil
-       :underline nil
-       :foreground nil
-       :background nil))
+  '((t :background "DarkGreen" :extend t))
   "Face for the root node of a thread when it is folded."
   :group 'mu4e-thread-folding)
 
 (defface mu4e-thread-folding-child-face
   `((t :extend t
-       :overline nil
-       :underline nil
-       :foreground nil
-       :background ,(color-lighten
-                     (face-attribute 'default :background) 10)))
+       :foreground "Black"
+       :background "Darkseagreen2"))
   "Face for a thread when it is unfolded (child node)"
   :group 'mu4e-thread-folding)
 

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -186,7 +186,8 @@ This uses the mu4e private API and this might break in future releases."
                   ;; Overlay for child (whole line)
                   (child-overlay (make-overlay
                                   (line-beginning-position)
-                                  (+ 1 (line-end-position)))))
+                                  (+ 1 (line-end-position))))
+                  fstate)
              (setq folded (or (and (member id mu4e-headers--folded-items) t)
                               mu4e-thread-folding-all-folded))
              ;; We mark the root thread if and only if there's child
@@ -196,9 +197,7 @@ This uses the mu4e private API and this might break in future releases."
                    (setq root-unread-child (or root-unread-child unread))
                    ;; Child
                    (overlay-put child-overlay 'face child-face)
-                   (if (and folded (not unread))
-                       (overlay-put child-overlay 'invisible t)
-                     (overlay-put child-overlay 'invisible nil))
+                   (overlay-put child-overlay 'invisible (and folded (not unread)))
                    (overlay-put child-overlay 'priority overlay-priority)
                    (overlay-put child-overlay 'unread unread)
                    (overlay-put child-overlay 'thread-child t)
@@ -206,12 +205,11 @@ This uses the mu4e private API and this might break in future releases."
                    (overlay-put child-prefix-overlay 'display child-prefix)
                    (overlay-put child-prefix-overlay 'child-prefix t)
                    ;; Root
-                   (if (or root-unread-child (not folded))
-                       (progn
-                         (overlay-put root-overlay 'face root-unfolded-face)
-                         (overlay-put root-prefix-overlay 'display root-unfolded-prefix))
-                     (overlay-put root-overlay 'face root-folded-face)
-                     (overlay-put root-prefix-overlay 'display root-folded-prefix))
+                   (setq fstate (or root-unread-child (not folded)))
+                   (overlay-put root-overlay
+                                'face (if fstate root-unfolded-face root-folded-face))
+                   (overlay-put root-prefix-overlay
+                                'display (if fstate root-unfolded-prefix root-folded-prefix))
                    (overlay-put root-prefix-overlay 'root-prefix t)
                    (overlay-put root-overlay 'priority overlay-priority)
                    (overlay-put root-overlay 'thread-root t)

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -102,7 +102,7 @@
        :underline nil
        :foreground nil
        :background ,(color-lighten
-                     (face-attribute 'default :background) 5)))
+                     (face-attribute 'default :background) 10)))
   "Face for a thread when it is unfolded (child node)"
   :group 'mu4e-thread-folding)
 

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -241,8 +241,6 @@ This uses the mu4e private API and this might break in future releases."
 Unread message are not folded."
   (when (and (get-buffer "*mu4e-headers*") mu4e-headers-show-threads)
     (with-current-buffer "*mu4e-headers*"
-      (unless thread-id
-        (setq mu4e-thread-folding-all-folded value))
       (save-excursion
         (goto-char (point-min))
         (let ((root-overlay  nil)
@@ -317,7 +315,8 @@ Unread message are not folded."
 (defun mu4e-headers-toggle-fold-all ()
   "Toggle between all threads unfolded and all threads folded."
   (interactive)
-  (mu4e-headers-overlay-set-visibility (not mu4e-thread-folding-all-folded)))
+  (setq mu4e-thread-folding-all-folded (not mu4e-thread-folding-all-folded))
+  (mu4e-headers-overlay-set-visibility mu4e-thread-folding-all-folded))
 
 (defun mu4e-headers-fold-all ()
   "Fold all threads"

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -315,10 +315,7 @@ Unread message are not folded."
         (save-excursion
           (let (child-overlay root-overlay)
             (while (not (bobp))
-              (cl-loop for ov in (overlays-in (save-excursion
-                                                (forward-line 0)
-                                                (point))
-                                              (point-at-eol))
+              (cl-loop for ov in (overlays-at (point))
                        when (overlay-get ov 'thread-child)
                        return (setq child-overlay ov)
                        when (overlay-get ov 'thread-root)


### PR DESCRIPTION
Hello,
I worked recently on your package, very nice, thanks for it.
I couldn't use it because of several issues:

- Toggling always jumped to previous thread.
- Opening view buffer was loosing the mail in header buffer
- Opening view buffer was loosing the folded state
- Marking mails was corrupting header buffer [1]
- Thread arrow was at one space from edge and sometimes corrupting date
- Going to next email in folded state was going to next hidden mail, now go to next visual mail

And probably other small issues I forget.
I am sorry to not make a PR for each issue.
While working on it I also make modifications you may not like, feel free to remove:
- Removed newlines not indented in your code.
- Changed faces
- Remove interactivity in some functions
- Modify how mode is working (see below)
- Modify keymap (now belong to mode)

[1] will be fully fixed when this PR will be merged https://github.com/djcb/mu/pull/2034
In the meaning time one have to run `(mu4e-headers-mark-threads t)`.

Now to use this package we need to add the mode to mu4e-headers:

`(add-hook 'mu4e-headers-mode-hook 'mu4e-thread-folding-mode)`

Thanks.