### PR TITLE
Margin

### DIFF
--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -160,20 +160,14 @@ This uses the mu4e private API and this might break in future releases."
       (unless no-reset (setq mu4e-headers--folded-items nil))
       (setq left-margin-width 1)
       (set-window-buffer (selected-window) (current-buffer))
-      (let ((overlay-priority     -60)
+      (let ((overlay-priority     60)
             (folded               (string= mu4e-thread-folding-default-view 'folded))
             (child-face           'mu4e-thread-folding-child-face)
-            (child-prefix-beg     (car mu4e-thread-folding-child-prefix-position))
-            (child-prefix-end     (cdr mu4e-thread-folding-child-prefix-position))
-            (child-prefix         'mu4e-thread-folding-child-prefix-string)
             (root-id              nil)
             (root-overlay         nil)
-            (root-prefix-overlay  nil)
             (root-unread-child    nil)
             (root-folded-face     'mu4e-thread-folding-root-folded-face)
             (root-unfolded-face   'mu4e-thread-folding-root-unfolded-face)
-            (root-prefix-beg      (car mu4e-thread-folding-root-prefix-position))
-            (root-prefix-end      (cdr mu4e-thread-folding-root-prefix-position))
             (root-folded-prefix   mu4e-thread-folding-root-folded-prefix-string)
             (root-unfolded-prefix mu4e-thread-folding-root-unfolded-prefix-string))
         ;; store initial folded state
@@ -182,20 +176,10 @@ This uses the mu4e private API and this might break in future releases."
         (mu4e-headers-for-each
          (lambda (msg)
            (let* ((id     (mu4e-headers-get-thread-id msg))
-                  ;; Warning: might break in the future
-                  ;; (docid (mu4e-message-field msg :docid))
-                  ;; (prefix-start (save-excursion (mu4e~headers-goto-docid docid t)))
                   (unread (member 'unread (mu4e-message-field msg :flags)))
-                  ;; Overlay for child (prefix)
-                  ;; (child-prefix-overlay (make-overlay
-                  ;;                        (+ prefix-start child-prefix-beg)
-                  ;;                        (+ prefix-start child-prefix-end)))
-                  ;; Overlay for child (whole line)
                   (child-overlay (make-overlay
                                   (line-beginning-position)
-                                  (+ 1 (line-end-position))
-                                  ;; (line-end-position)
-                                  )))
+                                  (+ 1 (line-end-position)))))
              (setq folded (or (and (member id mu4e-headers--folded-items) t)
                               mu4e-thread-folding-all-folded))
              ;; We mark the root thread if and only if there's child
@@ -212,8 +196,6 @@ This uses the mu4e private API and this might break in future releases."
                    (overlay-put child-overlay 'unread unread)
                    (overlay-put child-overlay 'thread-child t)
                    (overlay-put child-overlay 'thread-id id)
-                   ;; (overlay-put child-prefix-overlay 'display child-prefix)
-                   ;; (overlay-put child-overlay 'before-string (propertize " " 'display `((margin left-margin) ,child-prefix)))
                    ;; Root
                    (if (or root-unread-child (not folded))
                        (progn
@@ -223,7 +205,6 @@ This uses the mu4e private API and this might break in future releases."
                      (overlay-put root-overlay 'before-string (propertize " " 'display `((margin left-margin) ,root-folded-prefix))))
                    (overlay-put root-overlay 'priority overlay-priority)
                    (overlay-put root-overlay 'thread-root t)
-                   ;; (overlay-put root-overlay 'prefix-overlay root-prefix-overlay)
                    (overlay-put root-overlay 'thread-id id)
                    (overlay-put root-overlay 'folded folded))
                ;; Else, set the new root (this relies on default message order in header's view)
@@ -231,10 +212,7 @@ This uses the mu4e private API and this might break in future releases."
                      root-unread-child nil
                      root-overlay (make-overlay
                                    (line-beginning-position)
-                                   (line-end-position)
-                                   ;; (+ 0 (line-beginning-position))
-                                   ;; (+ 1 (line-end-position))
-                                   ))))))))))
+                                   (line-end-position)))))))))))
 
 (defun mu4e-headers-overlay-set-visibility (value &optional thread-id)
   "Set the invisible property for all thread children or only the ones matching thread-id.

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -186,8 +186,7 @@ This uses the mu4e private API and this might break in future releases."
 
                   ;; Warning: might break in the future
                   (docid (mu4e-message-field msg :docid))
-                  (prefix-start (+ (length mu4e~mark-fringe)
-                                   (mu4e~headers-goto-docid docid t)))
+                  (prefix-start (save-excursion (mu4e~headers-goto-docid docid t)))
 
                   (unread (member 'unread (mu4e-message-field msg :flags)))
 
@@ -318,7 +317,6 @@ Unread message are not folded."
             (while (not (bobp))
               (cl-loop for ov in (overlays-in (save-excursion
                                                 (forward-line 0)
-                                                (move-to-column 3 t)
                                                 (point))
                                               (point-at-eol))
                        when (overlay-get ov 'thread-child)

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -158,7 +158,7 @@ This uses the mu4e private API and this might break in future releases."
       (remove-overlays (point-min) (point-max))
 
       (let ((overlay-priority     -60)
-            (folded               (if (string= mu4e-thread-folding-default-view 'folded) t nil))
+            (folded               (string= mu4e-thread-folding-default-view 'folded))
 
             (child-face           'mu4e-thread-folding-child-face)
             (child-prefix-beg     (car mu4e-thread-folding-child-prefix-position))

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -55,6 +55,8 @@
 (require 'mu4e)
 (require 'color)
 
+(defvar mu4e-thread-folding-mode nil)
+
 (defun color-darken (hexcolor percent)
   (pcase-let* ((`(,R ,G ,B) (color-name-to-rgb hexcolor))
                (`(,H ,S ,L) (color-rgb-to-hsl R G B))
@@ -263,7 +265,6 @@ Unread message are not folded."
         (goto-char (point-min))
         (let ((root-overlay  nil)
               (child-overlay nil)
-              (root-prefix-beg (car mu4e-thread-folding-root-prefix-position))
               (root-folded-face 'mu4e-thread-folding-root-folded-face)
               (root-unfolded-face 'mu4e-thread-folding-root-unfolded-face)
               (root-folded-prefix mu4e-thread-folding-root-folded-prefix-string)

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -367,49 +367,28 @@ Unread message are not folded."
         (let ((overlay (mu4e-headers-get-overlay 'thread-id)))
           (mu4e-headers-overlay-set-visibility nil (overlay-get overlay 'thread-id))))))
 
-(defvar mu4e-thread-folding-map
-  (make-sparse-keymap))
+(defvar mu4e-thread-folding-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map mu4e-headers-mode-map)
+    (define-key map (kbd "TAB") 'mu4e-headers-toggle-at-point)
+    (define-key map (kbd "S-<tab>") 'mu4e-headers-toggle-fold-all)
+    map))
 
-;; (define-key mu4e-thread-folding-map (kbd "<left>") 'mu4e-headers-fold-at-point)
-;; (define-key mu4e-thread-folding-map (kbd "<S-left>") 'mu4e-headers-fold-all)
-;; (define-key mu4e-thread-folding-map (kbd "<right>") 'mu4e-headers-unfold-at-point)
-;; (define-key mu4e-thread-folding-map (kbd "<S-right>") 'mu4e-headers-unfold-all)
-(define-key mu4e-thread-folding-map (kbd "TAB") 'mu4e-headers-toggle-at-point)
-(define-key mu4e-thread-folding-map (kbd "S-<tab>") 'mu4e-headers-toggle-fold-all)
-
-(define-minor-mode mu4e-thread-folding-mode
-  "Minor mode for folding threads in mu4e-headers view."
-  ;; The initial value - Set to 1 to enable by default
-  nil
-  ;; The indicator for the mode line.
-  " Threads"
-  ;; The minor mode keymap
-  mu4e-thread-folding-map
-  ;; Make mode global rather than buffer local
-  :global nil
-  ;; customization group
-  :group 'mu4e-thread-folding)
-
-;; Install hooks and keybindings
+;; Install hooks
 (defun mu4e-thread-folding-load ()
   "Install hooks."
   (add-hook 'mu4e-index-updated-hook #'mu4e-headers-mark-threads)
   (add-hook 'mu4e-headers-found-hook #'mu4e-headers-mark-threads))
 
-(mu4e-thread-folding-load)
+(define-minor-mode mu4e-thread-folding-mode
+  "Minor mode for folding threads in mu4e-headers view."
+  :group 'mu4e-thread-folding
+  :lighter " Threads"
+  (if mu4e-thread-folding-mode
+      (mu4e-thread-folding-load)
+    (remove-hook 'mu4e-index-updated-hook #'mu4e-headers-mark-threads)
+    (remove-hook 'mu4e-headers-found-hook #'mu4e-headers-mark-threads)))
 
-(defun mu4e-thread-folding-unload-function ()
-  "Handler for `unload-feature'."
-  (condition-case err
-      (progn
-        (remove-hook 'mu4e-index-updated-hook #'mu4e-headers-mark-threads)
-        (remove-hook 'mu4e-headers-found-hook #'mu4e-headers-mark-threads)
-        ;; Return nil if unloading was successful.  Refer to `unload-feature'.
-        nil)
-    ;; If any error occurred, return non-nil.
-    (error (progn
-             (message "Error unloading mu4e-thread-folding: %S %S" (car err) (cdr err))
-             t))))
 
 (provide 'mu4e-thread-folding)
 ;;; mu4e-thread-folding.el ends here

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -285,10 +285,9 @@ Unread message are not folded."
   (when (get-buffer "*mu4e-headers*")
     (with-current-buffer "*mu4e-headers*"
       (catch 'break
-        (save-excursion
-          (while (and (not (mu4e-headers--toggle-internal))
-                      (not (bobp)))
-            (forward-line -1)))))))
+        (while (and (not (mu4e-headers--toggle-internal))
+                    (not (bobp)))
+          (forward-line -1))))))
 
 (defun mu4e-headers--toggle-internal ()
   "Toggle visibility of the thread at point"

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -139,7 +139,7 @@ This uses the mu4e private API and this might break in future releases."
   (mu4e~headers-get-thread-info msg 'thread-id))
 
 
-(defun mu4e-headers-mark-threads (&optional no-reset)
+(defun mu4e-headers-mark-threads ()
   "Mark line in headers view with various information contained in overlays."
   (when (and (get-buffer "*mu4e-headers*") mu4e-headers-show-threads)
     (with-current-buffer "*mu4e-headers*"
@@ -147,7 +147,6 @@ This uses the mu4e private API and this might break in future releases."
       (unless mu4e-thread-folding-mode (mu4e-thread-folding-mode 1))
       ;; Remove all overlays
       (remove-overlays (point-min) (point-max))
-      (unless no-reset (setq mu4e-headers--folded-items nil))
       (set-window-margins (selected-window) 1)
       (let ((overlay-priority     -60)
             (folded               (string= mu4e-thread-folding-default-view 'folded))
@@ -263,10 +262,6 @@ Unread message are not folded."
               ;; Now switch to next line.
               (forward-line 1))))))))
 
-(defun mu4e-headers-mark-threads-no-reset ()
-  "Same as `mu4e-headers-mark-threads' but don't reset `mu4e-headers--folded-items'."
-  (mu4e-headers-mark-threads 'no-reset))
-
 (defun mu4e-headers-get-overlay (prop &optional index)
   "Get overlay at point having the PROP property"
   (let* ((index (or index 0))
@@ -300,10 +295,6 @@ Unread message are not folded."
     (cond (root-overlay
            (let ((id     (overlay-get root-overlay 'thread-id))
                  (folded (overlay-get root-overlay 'folded)))
-             (if folded
-                 (setq mu4e-headers--folded-items
-                       (delete id mu4e-headers--folded-items))
-               (push id mu4e-headers--folded-items))
              (mu4e-headers-overlay-set-visibility (not folded) id)
              (throw 'break t)))
           ((not child-overlay)

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -179,6 +179,7 @@ This uses the mu4e private API and this might break in future releases."
                    (overlay-put root-overlay 'thread-root t)
                    (overlay-put root-overlay 'thread-id id)
                    (overlay-put root-overlay 'folded folded)
+                   (overlay-put root-overlay 'priority overlay-priority)
                    (overlay-put root-overlay 'invisible 'root)
                    (overlay-put root-overlay 'prefix-docid docid-overlay)
                    (overlay-put

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -177,9 +177,7 @@ This uses the mu4e private API and this might break in future releases."
                    (setq root-unread-child (or root-unread-child unread))
                    ;; Child
                    (overlay-put child-overlay 'face child-face)
-                   (if (and folded (not unread))
-                       (overlay-put child-overlay 'invisible t)
-                     (overlay-put child-overlay 'invisible nil))
+                   (overlay-put child-overlay 'invisible (and folded (not unread)))
                    (overlay-put child-overlay 'priority overlay-priority)
                    (overlay-put child-overlay 'unread unread)
                    (overlay-put child-overlay 'thread-child t)

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -207,8 +207,6 @@ This uses the mu4e private API and this might break in future releases."
                                    (line-beginning-position)
                                    (line-end-position))
                      docid-overlay (make-overlay
-                                    ;; For this we need a space before
-                                    ;; the pesty docid cookie at bol.
                                     (car docid-pos)
                                     (cdr docid-pos)))))))))))
 

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -148,8 +148,6 @@ This uses the mu4e private API and this might break in future releases."
 
 (defun mu4e-headers-mark-threads ()
   "Mark line in headers view with various information contained in overlays."
-
-  (interactive)
   (when (and (get-buffer "*mu4e-headers*") mu4e-headers-show-threads)
     (with-current-buffer "*mu4e-headers*"
       ;; turn on minor mode for key bindings
@@ -257,8 +255,6 @@ This uses the mu4e private API and this might break in future releases."
 (defun mu4e-headers-overlay-set-visibility (value &optional thread-id)
   "Set the invisible property for all thread children or only the ones matching thread-id.
 Unread message are not folded."
-
-  (interactive)
   (when (and (get-buffer "*mu4e-headers*") mu4e-headers-show-threads)
     (with-current-buffer "*mu4e-headers*"
       (unless thread-id

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -340,7 +340,7 @@ Unread message are not folded."
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map mu4e-headers-mode-map)
     (define-key map (kbd "TAB") 'mu4e-headers-toggle-at-point)
-    (define-key map (kbd "<C-tab>") 'mu4e-headers-toggle-fold-all)
+    (define-key map (kbd "<S-tab>") 'mu4e-headers-toggle-fold-all)
     map))
 
 ;; Install hooks

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -94,6 +94,11 @@
   "Face for a thread when it is unfolded (child node)"
   :group 'mu4e-thread-folding)
 
+(defface mu4e-thread-folding-root-prefix-face
+  `((t :inherit default))
+  "Face for the root node thread when it is unfolded."
+  :group 'mu4e-thread-folding)
+
 (defcustom mu4e-thread-folding-default-view 'unfolded
   "Initial folding status ('folded or 'unfolded)."
   :type 'string
@@ -193,10 +198,14 @@ This uses the mu4e private API and this might break in future releases."
                    (overlay-put root-overlay 'prefix-docid docid-overlay)
                    (overlay-put
                     docid-overlay 'before-string
-                    (propertize " " 'display `((margin left-margin)
-                                               ,(if (or root-unread-child (not folded))
-                                                    root-unfolded-prefix
-                                                  root-folded-prefix))))
+                    (propertize
+                     " " 'display
+                     `((margin left-margin)
+                       ,(propertize
+                         (if (or root-unread-child (not folded))
+                             root-unfolded-prefix
+                           root-folded-prefix)
+                         'face 'mu4e-thread-folding-root-prefix-face))))
                    (overlay-put docid-overlay 'invisible 'docid)
                    (overlay-put docid-overlay 'priority 1)
                    (overlay-put docid-overlay 'root-prefix t))
@@ -261,9 +270,12 @@ Unread message are not folded."
                       (overlay-get root-overlay 'prefix-docid) 'before-string
                       (propertize
                        " " 'display
-                       `((margin left-margin) ,(if value
-                                                   root-folded-prefix
-                                                 root-unfolded-prefix))))
+                       `((margin left-margin)
+                         ,(propertize
+                           (if value
+                               root-folded-prefix
+                             root-unfolded-prefix)
+                           'face 'mu4e-thread-folding-root-prefix-face))))
                      (overlay-put
                       root-overlay 'face (if value
                                              root-folded-face

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -205,7 +205,7 @@ This uses the mu4e private API and this might break in future releases."
                      root-unread-child nil
                      root-overlay (make-overlay
                                    (line-beginning-position)
-                                   (line-end-position))
+                                   (1+ (line-end-position)))
                      docid-overlay (make-overlay
                                     (car docid-pos)
                                     (cdr docid-pos)))))))))))

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -380,6 +380,7 @@ Unread message are not folded."
   (add-hook 'mu4e-index-updated-hook #'mu4e-headers-mark-threads)
   (add-hook 'mu4e-headers-found-hook #'mu4e-headers-mark-threads))
 
+;;;###autoload
 (define-minor-mode mu4e-thread-folding-mode
   "Minor mode for folding threads in mu4e-headers view."
   :group 'mu4e-thread-folding

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -146,6 +146,7 @@ This uses the mu4e private API and this might break in future releases."
                              thereis (overlay-get ov name))
                do (delete-overlay ov))
       (unless no-reset (setq mu4e-headers--folded-items nil))
+      (setq-local left-margin-width 1)
       (set-window-margins (selected-window) 1)
       (let ((overlay-priority     -60)
             (folded               (string= mu4e-thread-folding-default-view 'folded))

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -371,7 +371,7 @@ Unread message are not folded."
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map mu4e-headers-mode-map)
     (define-key map (kbd "TAB") 'mu4e-headers-toggle-at-point)
-    (define-key map (kbd "S-<tab>") 'mu4e-headers-toggle-fold-all)
+    (define-key map (kbd "<C-tab>") 'mu4e-headers-toggle-fold-all)
     map))
 
 ;; Install hooks

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -54,6 +54,8 @@
 ;;; Code:
 (require 'mu4e)
 
+(defvar mu4e-thread-folding-mode nil)
+(defvar mu4e-headers--folded-items nil)
 
 (defgroup mu4e-thread-folding '()
   "Group for mu4e thread folding options"
@@ -72,6 +74,11 @@
 (defface mu4e-thread-folding-child-face
   `((t :inherit 'default))
   "Face for a thread when it is unfolded (child node)"
+  :group 'mu4e-thread-folding)
+
+(defface mu4e-thread-folding-root-prefix-face
+  `((t :inherit default))
+  "Face for the root node thread when it is unfolded."
   :group 'mu4e-thread-folding)
 
 (defcustom mu4e-thread-folding-default-view 'folded

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -104,7 +104,7 @@
   :type 'string
   :group 'mu4e-thread-folding)
 
-(defvar mu4e-thread-folding-all-folded t
+(defvar mu4e-thread-folding-all-folded nil
   "Record whether last fold-all state was folded.")
 
 (defun mu4e-headers-get-thread-id (msg)
@@ -212,7 +212,7 @@ Unread message are not folded."
   (when (and (get-buffer "*mu4e-headers*") mu4e-headers-show-threads)
     (with-current-buffer "*mu4e-headers*"
       (unless thread-id
-        (setq mu4e-thread-folding-all-folded (not value)))
+        (setq mu4e-thread-folding-all-folded value))
       (save-excursion
         (goto-char (point-min))
         (let ((root-overlay  nil)
@@ -308,7 +308,8 @@ Unread message are not folded."
 (defun mu4e-headers-toggle-fold-all ()
   "Toggle between all threads unfolded and all threads folded."
   (interactive)
-  (mu4e-headers-overlay-set-visibility mu4e-thread-folding-all-folded))
+  (mu4e-headers-overlay-set-visibility
+   (not mu4e-thread-folding-all-folded)))
 
 (defun mu4e-headers-fold-all ()
   "Fold all threads"
@@ -340,7 +341,7 @@ Unread message are not folded."
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map mu4e-headers-mode-map)
     (define-key map (kbd "TAB") 'mu4e-headers-toggle-at-point)
-    (define-key map (kbd "<S-tab>") 'mu4e-headers-toggle-fold-all)
+    (define-key map (kbd "<backtab>") 'mu4e-headers-toggle-fold-all)
     map))
 
 ;; Install hooks

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -151,6 +151,7 @@ This uses the mu4e private API and this might break in future releases."
                   (docid-pos (cons (mu4e~headers-goto-docid docid)
                                    (mu4e~headers-goto-docid docid t)))
                   (id     (mu4e-headers-get-thread-id msg))
+                  (flagged (member 'flagged (mu4e-message-field msg :flags)))
                   (unread (member 'unread (mu4e-message-field msg :flags)))
                   (child-overlay (make-overlay
                                   (line-beginning-position)
@@ -163,7 +164,8 @@ This uses the mu4e private API and this might break in future releases."
                    ;; unread-child indicates that there's at least one unread child
                    (setq root-unread-child (or root-unread-child unread))
                    ;; Child
-                   (overlay-put child-overlay 'face child-face)
+                   (when (and (not unread) (not flagged))
+                     (overlay-put child-overlay 'face child-face))
                    (overlay-put child-overlay 'invisible (and folded (not unread)))
                    (overlay-put child-overlay 'priority overlay-priority)
                    (overlay-put child-overlay 'unread unread)

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -102,7 +102,7 @@
        :underline nil
        :foreground nil
        :background ,(color-lighten
-                     (face-attribute 'default :background) 5)))
+                     (face-attribute 'default :background) 10)))
   "Face for a thread when it is unfolded (child node)"
   :group 'mu4e-thread-folding)
 

--- a/mu4e-thread-folding.el
+++ b/mu4e-thread-folding.el
@@ -315,10 +315,7 @@ Unread message are not folded."
         (save-excursion
           (let (child-overlay root-overlay)
             (while (not (bobp))
-              (cl-loop for ov in (overlays-in (save-excursion
-                                                (forward-line 0)
-                                                (point))
-                                              (point-at-eol))
+              (cl-loop for ov in (overlays-at (point))
                        when (overlay-get ov 'thread-child)
                        return (setq child-overlay ov)
                        when (overlay-get ov 'thread-root)


### PR DESCRIPTION
Same comments as #21 but this one is using margin to display the prefix arrows which is much better.
In addition of looking nicer, it fixes several issues with cursor position, contiguous overlays not playing well etc...
The reason is that now prefix is attached in margin BEFORE the docid cookie whereas previously it was added after (before mu4e~mark-fringe).

![Capture d’écran_2021-06-15_11-46-40](https://user-images.githubusercontent.com/1533939/122033583-f3140800-cdd0-11eb-8afa-c55e98d98aa7.png)
